### PR TITLE
Add a patch for invalid `SUNDIALS_EXPORT` macro in static lib in `-devel` variant

### DIFF
--- a/recipe/fix-win-static-and-shared.patch
+++ b/recipe/fix-win-static-and-shared.patch
@@ -24,3 +24,21 @@ index ca0d22619..6a029978c 100644
        else()
          set_target_properties(${_actual_target_name} PROPERTIES
            OUTPUT_NAME ${target}
+@@ -200,7 +200,7 @@ macro(sundials_add_library target)
+ 
+     # add compile definitions to object library for SUNDIALS_EXPORT
+     if(${_libtype} MATCHES "STATIC")
+-      target_compile_definitions(${obj_target} PRIVATE SUNDIALS_STATIC_DEFINE)
++      target_compile_definitions(${obj_target} PUBLIC SUNDIALS_STATIC_DEFINE)
+     else()
+       target_compile_definitions(${obj_target} PRIVATE sundials_core_EXPORTS)
+     endif()
+@@ -296,7 +296,7 @@ macro(sundials_add_library target)
+ 
+       # add compile definitions for SUNDIALS_EXPORT
+       if(${_libtype} MATCHES "STATIC")
+-        target_compile_definitions(${_actual_target_name} PRIVATE SUNDIALS_STATIC_DEFINE)
++        target_compile_definitions(${_actual_target_name} PUBLIC SUNDIALS_STATIC_DEFINE)
+       else()
+         target_compile_definitions(${obj_target} PRIVATE sundials_core_EXPORTS)
+       endif()

--- a/recipe/fix-win-static-and-shared.patch
+++ b/recipe/fix-win-static-and-shared.patch
@@ -2,6 +2,24 @@ diff --git a/cmake/macros/SundialsAddLibrary.cmake b/cmake/macros/SundialsAddLib
 index ca0d22619..6a029978c 100644
 --- a/cmake/macros/SundialsAddLibrary.cmake
 +++ b/cmake/macros/SundialsAddLibrary.cmake
+@@ -200,7 +200,7 @@ macro(sundials_add_library target)
+ 
+     # add compile definitions to object library for SUNDIALS_EXPORT
+     if(${_libtype} MATCHES "STATIC")
+-      target_compile_definitions(${obj_target} PRIVATE SUNDIALS_STATIC_DEFINE)
++      target_compile_definitions(${obj_target} PUBLIC SUNDIALS_STATIC_DEFINE)
+     else()
+       target_compile_definitions(${obj_target} PRIVATE sundials_core_EXPORTS)
+     endif()
+@@ -296,7 +296,7 @@ macro(sundials_add_library target)
+ 
+       # add compile definitions for SUNDIALS_EXPORT
+       if(${_libtype} MATCHES "STATIC")
+-        target_compile_definitions(${_actual_target_name} PRIVATE SUNDIALS_STATIC_DEFINE)
++        target_compile_definitions(${_actual_target_name} PUBLIC SUNDIALS_STATIC_DEFINE)
+       else()
+         target_compile_definitions(${obj_target} PRIVATE sundials_core_EXPORTS)
+       endif()
 @@ -325,10 +325,17 @@ macro(sundials_add_library target)
  
        # set the correct output name
@@ -24,21 +42,3 @@ index ca0d22619..6a029978c 100644
        else()
          set_target_properties(${_actual_target_name} PROPERTIES
            OUTPUT_NAME ${target}
-@@ -200,7 +200,7 @@ macro(sundials_add_library target)
- 
-     # add compile definitions to object library for SUNDIALS_EXPORT
-     if(${_libtype} MATCHES "STATIC")
--      target_compile_definitions(${obj_target} PRIVATE SUNDIALS_STATIC_DEFINE)
-+      target_compile_definitions(${obj_target} PUBLIC SUNDIALS_STATIC_DEFINE)
-     else()
-       target_compile_definitions(${obj_target} PRIVATE sundials_core_EXPORTS)
-     endif()
-@@ -296,7 +296,7 @@ macro(sundials_add_library target)
- 
-       # add compile definitions for SUNDIALS_EXPORT
-       if(${_libtype} MATCHES "STATIC")
--        target_compile_definitions(${_actual_target_name} PRIVATE SUNDIALS_STATIC_DEFINE)
-+        target_compile_definitions(${_actual_target_name} PUBLIC SUNDIALS_STATIC_DEFINE)
-       else()
-         target_compile_definitions(${obj_target} PRIVATE sundials_core_EXPORTS)
-       endif()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     sha256: 6b2a914209c1e007ccbfb0aa864b9782377ef45262376b611a193963e43c1972
 
 build:
-  number: 3
+  number: 4
 
 outputs:
   - name: {{ name }}


### PR DESCRIPTION
Add a patch for invalid `SUNDIALS_EXPORT` macro in static lib in `-devel` variant

See https://github.com/LLNL/sundials/issues/454#issuecomment-2114549047

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
